### PR TITLE
fix(win32): ignore ERROR_CLASS_ALREADY_EXISTS

### DIFF
--- a/winio-ui-win32/Cargo.toml
+++ b/winio-ui-win32/Cargo.toml
@@ -65,4 +65,5 @@ sync-unsafe-cell = { version = "0.1", optional = true }
 embed-resource = "3"
 
 [features]
+ignore-class-conflict = []
 dark-mode = ["dep:slim-detours-sys", "dep:sync-unsafe-cell"]

--- a/winio-ui-win32/src/ui/window.rs
+++ b/winio-ui-win32/src/ui/window.rs
@@ -7,11 +7,10 @@ use std::{
 use compio::driver::syscall;
 use inherit_methods_macro::inherit_methods;
 use widestring::{U16CStr, U16CString, u16cstr};
+#[cfg(feature = "ignore-class-conflict")]
+use windows_sys::Win32::Foundation::ERROR_CLASS_ALREADY_EXISTS;
 use windows_sys::Win32::{
-    Foundation::{
-        ERROR_CLASS_ALREADY_EXISTS, ERROR_INVALID_HANDLE, HWND, LPARAM, LRESULT, POINT,
-        SetLastError, WPARAM,
-    },
+    Foundation::{ERROR_INVALID_HANDLE, HWND, LPARAM, LRESULT, POINT, SetLastError, WPARAM},
     Graphics::Gdi::{GetStockObject, MapWindowPoints, WHITE_BRUSH},
     System::LibraryLoader::GetModuleHandleW,
     UI::{
@@ -343,6 +342,7 @@ fn register() {
     };
     match syscall!(BOOL, unsafe { RegisterClassExW(&cls) }) {
         Ok(_) => {}
+        #[cfg(feature = "ignore-class-conflict")]
         Err(e) if e.raw_os_error() == Some(ERROR_CLASS_ALREADY_EXISTS as _) => {
             // The class is already registered. We choose to ignore this error,
             // and hope that the class is still valid.

--- a/winio/Cargo.toml
+++ b/winio/Cargo.toml
@@ -58,4 +58,5 @@ enable_log = ["compio/enable_log", "compio-log/enable_log"]
 
 nightly = ["compio/nightly", "cyper/nightly"]
 win32-dark-mode = ["winio-ui-win32/dark-mode"]
+win32-ignore-class-conflict = ["winio-ui-win32/ignore-class-conflict"]
 objc-static = ["winio-ui-app-kit/objc-static"]


### PR DESCRIPTION
Closes #35 

The window class we register has nothing special. If we ignore the conflict error, some others might register the window class before us. I don't know if it will cause an attack.

The window class name is changed (the old name contains some history of my code...) and appended with the crate version.