### PR TITLE
fix(winio): use BufResult pattern for read_to_end_at in fs example

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/winio.iml" filepath="$PROJECT_DIR$/.idea/winio.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/winio.iml
+++ b/.idea/winio.iml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/winio-callback/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-elm/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-handle/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-layout/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-pollable/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-primitive/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-app-kit/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-gtk/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-qt/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-win32/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-windows-common/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio-ui-winui/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/winio/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/winio/examples/fs.rs
+++ b/winio/examples/fs.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use compio::{fs::File, io::AsyncReadAtExt, runtime::spawn};
+use compio::{fs::File, io::AsyncReadAtExt, runtime::spawn, BufResult};
 use winio::prelude::*;
 
 fn main() {
@@ -164,7 +164,7 @@ impl Component for MainModel {
 
 async fn read_file(path: impl AsRef<Path>) -> io::Result<String> {
     let file = File::open(path).await?;
-    let (_, buffer) = file.read_to_end_at(vec![], 0).await?;
+    let BufResult(_, buffer) = file.read_to_end_at(vec![], 0).await;
     String::from_utf8(buffer).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 


### PR DESCRIPTION
Fix the compilation error:
error[E0277]: the `?` operator can only be applied to values that implement `Try`
   --> winio\examples\fs.rs:167:23
    |
167 |     let (_, buffer) = file.read_to_end_at(vec![], 0).await?;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `BufResult<usize, Vec<u8>>`
    |
    = help: the trait `Try` is not implemented for `BufResult<usize, Vec<u8>>`

