### PR TITLE
fix(windows): check version for backdrop support

### DIFF
--- a/winio-ui-windows-common/src/backdrop.rs
+++ b/winio-ui-windows-common/src/backdrop.rs
@@ -9,7 +9,7 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::Result;
+use crate::{Result, get_nt_build};
 
 /// Backdrop effects for windows.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -29,6 +29,9 @@ pub enum Backdrop {
 /// # Safety
 /// The caller must ensure that `handle` is a valid window handle.
 pub unsafe fn get_backdrop(handle: HWND) -> Result<Backdrop> {
+    if get_nt_build() < 22621 {
+        return Ok(Backdrop::None);
+    }
     let mut style = 0;
     let res = unsafe {
         DwmGetWindowAttribute(
@@ -54,6 +57,9 @@ pub unsafe fn get_backdrop(handle: HWND) -> Result<Backdrop> {
 /// # Safety
 /// The caller must ensure that `handle` is a valid window handle.
 pub unsafe fn set_backdrop(handle: HWND, backdrop: Backdrop) -> Result<bool> {
+    if get_nt_build() < 22621 {
+        return Ok(false);
+    }
     let style = match backdrop {
         Backdrop::Acrylic => DWMSBT_TRANSIENTWINDOW,
         Backdrop::Mica => DWMSBT_MAINWINDOW,

--- a/winio-ui-windows-common/src/darkmode/hook.rs
+++ b/winio-ui-windows-common/src/darkmode/hook.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeMap,
     mem::MaybeUninit,
-    ptr::{null, null_mut},
+    ptr::null,
     sync::{LazyLock, Mutex, Once},
 };
 
@@ -50,12 +50,7 @@ use windows_sys::{
 };
 
 use super::{PreferredAppMode, WHITE, WinBrush, u16_string_eq_ignore_case};
-use crate::{Error, Result, darkmode::u16_string_starts_with_ignore_case};
-
-#[link(name = "ntdll")]
-unsafe extern "system" {
-    fn RtlGetNtVersionNumbers(major: *mut u32, minor: *mut u32, build: *mut u32);
-}
+use crate::{Error, Result, darkmode::u16_string_starts_with_ignore_case, get_nt_build};
 
 #[link(name = "uxtheme", kind = "raw-dylib")]
 unsafe extern "system" {
@@ -71,14 +66,6 @@ unsafe extern "system" {
     fn SetPreferredAppMode(m: PreferredAppMode) -> PreferredAppMode;
     #[link_ordinal(136)]
     fn FlushMenuThemes();
-}
-
-#[inline]
-fn get_nt_build() -> u32 {
-    let mut build = 0;
-    unsafe { RtlGetNtVersionNumbers(null_mut(), null_mut(), &mut build) };
-    build &= !0xF0000000;
-    build
 }
 
 pub fn set_preferred_app_mode(m: PreferredAppMode) -> PreferredAppMode {

--- a/winio-ui-windows-common/src/lib.rs
+++ b/winio-ui-windows-common/src/lib.rs
@@ -7,6 +7,9 @@
 
 pub use windows::core::{Error, Result};
 
+mod version;
+pub(crate) use version::*;
+
 mod accent;
 pub use accent::*;
 

--- a/winio-ui-windows-common/src/version.rs
+++ b/winio-ui-windows-common/src/version.rs
@@ -1,0 +1,14 @@
+use std::ptr::null_mut;
+
+#[link(name = "ntdll")]
+unsafe extern "system" {
+    fn RtlGetNtVersionNumbers(major: *mut u32, minor: *mut u32, build: *mut u32);
+}
+
+#[inline]
+pub(crate) fn get_nt_build() -> u32 {
+    let mut build = 0;
+    unsafe { RtlGetNtVersionNumbers(null_mut(), null_mut(), &mut build) };
+    build &= !0xF0000000;
+    build
+}


### PR DESCRIPTION
@mokurin000 Could you try it on Windows 10? You only need to patch `winio-ui-windows-common`.