### PR TITLE
refactor: use OsString as path type

### DIFF
--- a/winio-example/src/lib.rs
+++ b/winio-example/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(any(feature = "compio-compat", feature = "media"))]
-use std::path::PathBuf;
+use std::ffi::OsString;
 use std::{future::Future, pin::Pin};
 
 pub use anyhow::{Error, Result};
@@ -36,22 +36,22 @@ pub enum MainMessage {
     #[cfg(feature = "compio-compat")]
     ChooseSaveFile,
     #[cfg(feature = "compio-compat")]
-    OpenFile(PathBuf),
+    OpenFile(OsString),
     #[cfg(feature = "compio-compat")]
-    SaveFile(PathBuf),
+    SaveFile(OsString),
     #[cfg(feature = "compio-compat")]
     ChooseFolder,
     #[cfg(feature = "compio-compat")]
-    OpenFolder(PathBuf),
+    OpenFolder(OsString),
     ShowMessage(MessageBox),
     #[cfg(feature = "media")]
     ChooseMedia,
     #[cfg(feature = "media")]
-    OpenMedia(PathBuf),
+    OpenMedia(OsString),
     #[cfg(all(feature = "webview", feature = "compio-compat"))]
     ChooseMarkdown,
     #[cfg(all(feature = "webview", feature = "compio-compat"))]
-    OpenMarkdown(PathBuf),
+    OpenMarkdown(OsString),
     #[cfg(windows)]
     ChooseBackdrop(Backdrop),
     #[cfg(target_os = "macos")]

--- a/winio-example/src/subviews/fs.rs
+++ b/winio-example/src/subviews/fs.rs
@@ -1,7 +1,7 @@
 use std::{
+    ffi::{OsStr, OsString},
     io,
     ops::Deref,
-    path::{Path, PathBuf},
 };
 
 use compio::{
@@ -39,8 +39,8 @@ pub enum FsPageEvent {
 pub enum FsPageMessage {
     ChooseFile,
     ChooseSaveFile,
-    OpenFile(PathBuf),
-    SaveFile(PathBuf),
+    OpenFile(OsString),
+    SaveFile(OsString),
     Fetch(FsFetchStatus),
 }
 
@@ -183,13 +183,13 @@ impl Deref for FsPage {
     }
 }
 
-async fn read_file(path: impl AsRef<Path>) -> Result<String> {
+async fn read_file(path: impl AsRef<OsStr>) -> Result<String> {
     let file = UriFile::open(path).await?;
     let (_, buffer) = buf_try!(@try file.read_to_end_at(vec![], 0).await);
     Ok(String::from_utf8(buffer).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
 }
 
-async fn fetch(path: impl AsRef<Path>, sender: ComponentSender<FsPage>) {
+async fn fetch(path: impl AsRef<OsStr>, sender: ComponentSender<FsPage>) {
     sender.post(FsPageMessage::Fetch(FsFetchStatus::Loading));
     let status = match read_file(path).await {
         Ok(text) => FsFetchStatus::Complete(text),
@@ -198,13 +198,13 @@ async fn fetch(path: impl AsRef<Path>, sender: ComponentSender<FsPage>) {
     sender.post(FsPageMessage::Fetch(status));
 }
 
-async fn write_file(path: impl AsRef<Path>, data: String) -> Result<()> {
+async fn write_file(path: impl AsRef<OsStr>, data: String) -> Result<()> {
     let mut file = UriFile::create(path).await?;
     file.write_all_at(data, 0).await.0?;
     Ok(())
 }
 
-async fn save(path: impl AsRef<Path>, data: String, sender: ComponentSender<FsPage>) {
+async fn save(path: impl AsRef<OsStr>, data: String, sender: ComponentSender<FsPage>) {
     match write_file(path, data).await {
         Ok(()) => {}
         Err(e) => {

--- a/winio-example/src/subviews/gallery.rs
+++ b/winio-example/src/subviews/gallery.rs
@@ -1,8 +1,7 @@
 use std::{
     collections::BTreeMap,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     ops::Deref,
-    path::{Path, PathBuf},
 };
 
 use compio::{
@@ -78,7 +77,7 @@ pub enum GalleryPageMessage {
     Redraw,
     ChooseFolder,
     Start,
-    OpenFolder(PathBuf),
+    OpenFolder(OsString),
     Clear,
     Append(OsString, DynamicImage),
     List(ObservableVecEvent<String>),
@@ -210,7 +209,7 @@ impl Component for GalleryPage {
                 Ok(false)
             }
             GalleryPageMessage::Start => {
-                let p = PathBuf::from(self.entry.text()?);
+                let p = OsString::from(self.entry.text()?);
                 let sender = sender.clone();
                 spawn(fetch(p, sender)).detach();
                 Ok(true)
@@ -369,7 +368,7 @@ impl Deref for GalleryPage {
     }
 }
 
-async fn fetch(path: impl AsRef<Path>, sender: ComponentSender<GalleryPage>) {
+async fn fetch(path: impl AsRef<OsStr>, sender: ComponentSender<GalleryPage>) {
     sender.post(GalleryPageMessage::Clear);
     let dir = match read_uri_dir(path) {
         Ok(dir) => dir,

--- a/winio-example/src/subviews/markdown.rs
+++ b/winio-example/src/subviews/markdown.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    ffi::{OsStr, OsString},
     io,
     net::SocketAddr,
     ops::Deref,
@@ -42,7 +43,7 @@ pub enum MarkdownPageEvent {
 pub enum MarkdownPageMessage {
     SetAddr(SocketAddr),
     ChooseFile,
-    OpenFile(PathBuf),
+    OpenFile(OsString),
     Fetch(MarkdownFetchStatus),
 }
 
@@ -154,7 +155,7 @@ impl Component for MarkdownPage {
             }
             MarkdownPageMessage::OpenFile(p) => {
                 self.label.set_text(p.to_str().unwrap_or_default())?;
-                *self.markdown_path.borrow_mut() = p.clone();
+                *self.markdown_path.borrow_mut() = p.clone().into();
                 spawn(fetch(p, sender.clone())).detach();
                 Ok(true)
             }
@@ -286,22 +287,22 @@ impl Drop for MarkdownPage {
     }
 }
 
-async fn read_file(path: impl AsRef<Path>) -> Result<Vec<u8>> {
+async fn read_file(path: impl AsRef<OsStr>) -> Result<Vec<u8>> {
     let file = UriFile::open(path).await?;
     let (_, buffer) = buf_try!(@try file.read_to_end_at(vec![], 0).await);
     Ok(buffer)
 }
 
-async fn read_file_content(path: impl AsRef<Path>) -> Result<String> {
+async fn read_file_content(path: impl AsRef<OsStr>) -> Result<String> {
     let path = path.as_ref();
-    if path.as_os_str().is_empty() {
+    if path.is_empty() {
         return Ok(String::new());
     }
     let bytes = read_file(path).await?;
     Ok(String::from_utf8(bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
 }
 
-async fn fetch(path: impl AsRef<Path>, sender: ComponentSender<MarkdownPage>) {
+async fn fetch(path: impl AsRef<OsStr>, sender: ComponentSender<MarkdownPage>) {
     let status = match read_file_content(path).await {
         Ok(text) => MarkdownFetchStatus::Complete(text),
         Err(e) => MarkdownFetchStatus::Error(format!("{e:?}")),

--- a/winio-example/src/subviews/media.rs
+++ b/winio-example/src/subviews/media.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, path::PathBuf, time::Duration};
+use std::{ffi::OsString, ops::Deref, time::Duration};
 
 use url::Url;
 use winio::prelude::*;
@@ -40,7 +40,7 @@ pub enum MediaPageMessage {
     Tick,
     Play,
     ChooseFile,
-    OpenFile(PathBuf),
+    OpenFile(OsString),
 }
 
 impl Component for MediaPage {

--- a/winio-ui-android/src/compat/file.rs
+++ b/winio-ui-android/src/compat/file.rs
@@ -1,7 +1,6 @@
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     os::fd::{BorrowedFd, FromRawFd, IntoRawFd},
-    path::{Path, PathBuf},
 };
 
 use compio::fs::File;
@@ -21,7 +20,7 @@ use crate::{
     vm_exec,
 };
 
-fn open_uri_with_mode(uri: &Path, mode: &str) -> Result<File> {
+fn open_uri_with_mode(uri: &OsStr, mode: &str) -> Result<File> {
     vm_exec(|env| {
         let act = current_activity(env)?;
         let context = env.cast_local::<Context>(act)?;
@@ -39,27 +38,27 @@ fn open_uri_with_mode(uri: &Path, mode: &str) -> Result<File> {
 
 pub use compio::fs::File as UriFile;
 
-pub async fn open_uri(uri: &Path) -> Result<File> {
+pub async fn open_uri(uri: &OsStr) -> Result<File> {
     open_uri_with_mode(uri, "r")
 }
 
-pub async fn create_uri(uri: &Path) -> Result<File> {
+pub async fn create_uri(uri: &OsStr) -> Result<File> {
     open_uri_with_mode(uri, "w")
 }
 
-pub async fn update_uri(uri: &Path) -> Result<File> {
+pub async fn update_uri(uri: &OsStr) -> Result<File> {
     open_uri_with_mode(uri, "rw")
 }
 
 #[derive(Debug)]
 pub struct UriDirEntry {
     name: String,
-    uri: PathBuf,
+    uri: OsString,
     mime: String,
 }
 
 impl UriDirEntry {
-    pub fn path(&self) -> PathBuf {
+    pub fn path(&self) -> OsString {
         self.uri.clone()
     }
 
@@ -99,7 +98,7 @@ pub struct UriReadDir {
     cursor: Global<Cursor<'static>>,
 }
 
-pub fn read_dir(uri: &Path) -> Result<UriReadDir> {
+pub fn read_dir(uri: &OsStr) -> Result<UriReadDir> {
     vm_exec(|env| {
         let act = current_activity(env)?;
         let context = env.cast_local::<Context>(act)?;
@@ -169,7 +168,7 @@ impl Iterator for UriReadDir {
 
             Ok(Some(UriDirEntry {
                 name,
-                uri: PathBuf::from(uri),
+                uri: OsString::from(uri),
                 mime,
             }))
         })

--- a/winio-ui-android/src/dialogs/filebox.rs
+++ b/winio-ui-android/src/dialogs/filebox.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::PathBuf,
+    ffi::OsString,
     sync::{Arc, Mutex},
 };
 
@@ -28,12 +28,12 @@ use crate::{
 
 struct ProxyCallback {
     proxy: DynamicProxy,
-    rx: Arc<AsyncMutex<UnboundedReceiver<Vec<PathBuf>>>>,
+    rx: Arc<AsyncMutex<UnboundedReceiver<Vec<OsString>>>>,
 }
 
 impl ProxyCallback {
     pub fn new(env: &mut Env, context: &Activity) -> jni::errors::Result<Self> {
-        let (tx, rx) = futures_channel::mpsc::unbounded::<Vec<PathBuf>>();
+        let (tx, rx) = futures_channel::mpsc::unbounded::<Vec<OsString>>();
         let proxy = DynamicProxy::build(
             env,
             &LoaderContext::FromObject(context),
@@ -44,7 +44,7 @@ impl ProxyCallback {
                     let uri = unsafe { Uri::from_raw(env, result.into_raw()) };
                     if !uri.is_null() {
                         let path = uri.to_string(env)?.try_to_string(env)?;
-                        tx.unbounded_send(vec![PathBuf::from(path)]).ok();
+                        tx.unbounded_send(vec![OsString::from(path)]).ok();
                     } else {
                         tx.unbounded_send(vec![]).ok();
                     }
@@ -56,7 +56,7 @@ impl ProxyCallback {
                         let uri = unsafe { Uri::from_raw(env, item.into_raw()) };
                         if !uri.is_null() {
                             let path = uri.to_string(env)?.try_to_string(env)?;
-                            paths.push(PathBuf::from(path));
+                            paths.push(OsString::from(path));
                         }
                     }
                     tx.unbounded_send(paths).ok();
@@ -76,7 +76,7 @@ impl ProxyCallback {
         self.proxy.as_ref()
     }
 
-    pub fn receiver(&self) -> Arc<AsyncMutex<UnboundedReceiver<Vec<PathBuf>>>> {
+    pub fn receiver(&self) -> Arc<AsyncMutex<UnboundedReceiver<Vec<OsString>>>> {
         self.rx.clone()
     }
 }
@@ -157,7 +157,7 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -173,7 +173,7 @@ impl FileBox {
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -188,7 +188,7 @@ impl FileBox {
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -204,7 +204,7 @@ impl FileBox {
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -226,7 +226,7 @@ fn filebox(
     open: bool,
     multiple: bool,
     folder: bool,
-) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
     vm_exec(|env| {
         let (launcher, input) = if open && multiple {
             (LAUNCHER_GET_MULTIPLE_CONTENTS.lock().unwrap(), Some("*/*"))

--- a/winio-ui-app-kit/src/dialogs/filebox.rs
+++ b/winio-ui-app-kit/src/dialogs/filebox.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, path::PathBuf, rc::Rc};
+use std::{cell::Cell, ffi::OsString, rc::Rc};
 
 use block2::StackBlock;
 use futures_util::{FutureExt, TryFutureExt, future::Either};
@@ -60,7 +60,7 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -76,7 +76,7 @@ impl FileBox {
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -92,7 +92,7 @@ impl FileBox {
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -108,7 +108,7 @@ impl FileBox {
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(
             parent,
             self.title,
@@ -224,27 +224,27 @@ fn filebox(
 struct FileBoxInner(Option<Retained<NSSavePanel>>);
 
 impl FileBoxInner {
-    pub fn result(self) -> Result<Option<PathBuf>> {
+    pub fn result(self) -> Result<Option<OsString>> {
         if let Some(dialog) = self.0 {
             catch(|| {
                 dialog
                     .URL()
                     .and_then(|url| url.path())
-                    .map(|s| PathBuf::from(from_nsstring(&s)))
+                    .map(|s| OsString::from(from_nsstring(&s)))
             })
         } else {
             Ok(None)
         }
     }
 
-    pub fn results(self) -> Result<Vec<PathBuf>> {
+    pub fn results(self) -> Result<Vec<OsString>> {
         if let Some(dialog) = self.0 {
             let dialog: Retained<NSOpenPanel> = unsafe { Retained::cast_unchecked(dialog) };
             catch(|| {
                 dialog
                     .URLs()
                     .iter()
-                    .filter_map(|url| url.path().map(|s| PathBuf::from(from_nsstring(&s))))
+                    .filter_map(|url| url.path().map(|s| OsString::from(from_nsstring(&s))))
                     .collect()
             })
         } else {

--- a/winio-ui-gtk/src/dialogs/filebox.rs
+++ b/winio-ui-gtk/src/dialogs/filebox.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{ffi::OsString, path::PathBuf};
 
 use futures_util::TryFutureExt;
 use gtk4::{
@@ -55,18 +55,18 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(self
             .filebox()
             .open_future(parent.as_ref().map(|w| w.as_window().to_gtk()))
-            .map_ok(|res| res.path())
+            .map_ok(|res| res.path().map(PathBuf::into_os_string))
             .map_err(|e| e.into()))
     }
 
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         Ok(self
             .filebox()
             .open_multiple_future(parent.as_ref().map(|w| w.as_window().to_gtk()))
@@ -75,6 +75,7 @@ impl FileBox {
                     .filter_map(|f| f.ok())
                     .filter_map(|f| f.dynamic_cast::<gtk4::gio::File>().ok())
                     .filter_map(|f| f.path())
+                    .map(PathBuf::into_os_string)
                     .collect()
             })
             .map_err(|e| e.into()))
@@ -83,22 +84,22 @@ impl FileBox {
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(self
             .filebox()
             .select_folder_future(parent.as_ref().map(|w| w.as_window().to_gtk()))
-            .map_ok(|res| res.path())
+            .map_ok(|res| res.path().map(PathBuf::into_os_string))
             .map_err(|e| e.into()))
     }
 
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(self
             .filebox()
             .save_future(parent.as_ref().map(|w| w.as_window().to_gtk()))
-            .map_ok(|res| res.path())
+            .map_ok(|res| res.path().map(PathBuf::into_os_string))
             .map_err(|e| e.into()))
     }
 

--- a/winio-ui-qt/src/dialogs/filebox.rs
+++ b/winio-ui-qt/src/dialogs/filebox.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, ptr::null_mut};
+use std::{ffi::OsString, ptr::null_mut};
 
 use cxx::{ExternType, type_id};
 use futures_util::{FutureExt, TryFutureExt};
@@ -53,7 +53,7 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.filebox(parent, true, false, false)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -61,14 +61,14 @@ impl FileBox {
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         self.filebox(parent, true, true, false)
     }
 
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.filebox(parent, true, false, true)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -76,7 +76,7 @@ impl FileBox {
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.filebox(parent, false, false, false)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -87,7 +87,7 @@ impl FileBox {
         open: bool,
         multiple: bool,
         folder: bool,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         let parent = parent.map(|p| p.as_window().as_qt()).unwrap_or(null_mut());
         let mut b = unsafe { ffi::new_file_dialog(parent) }?;
 
@@ -140,7 +140,7 @@ impl FileBox {
 
             Ok(ffi::file_dialog_files(&b)?
                 .into_iter()
-                .map(PathBuf::from)
+                .map(OsString::from)
                 .collect())
         }))
     }

--- a/winio-ui-stub/src/dialogs/filebox.rs
+++ b/winio-ui-stub/src/dialogs/filebox.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::ffi::OsString;
 
 use winio_handle::AsWindow;
 
@@ -31,28 +31,28 @@ impl FileBox {
     pub fn open(
         self,
         _parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(not_impl_fut())
     }
 
     pub fn open_multiple(
         self,
         _parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         Ok(not_impl_fut())
     }
 
     pub fn open_folder(
         self,
         _parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(not_impl_fut())
     }
 
     pub fn save(
         self,
         _parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         Ok(not_impl_fut())
     }
 }

--- a/winio-ui-ui-kit/src/dialogs/filebox.rs
+++ b/winio-ui-ui-kit/src/dialogs/filebox.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::ffi::OsString;
 
 use futures_util::TryFutureExt;
 use objc2::{
@@ -66,7 +66,7 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(parent, self.filters, false, false, false)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -74,14 +74,14 @@ impl FileBox {
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         filebox(parent, self.filters, true, false, false)
     }
 
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(parent, self.filters, false, true, false)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -89,7 +89,7 @@ impl FileBox {
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         filebox(parent, self.filters, false, false, true)
             .map(|fut| fut.map_ok(|res| res.into_iter().next()))
     }
@@ -101,7 +101,7 @@ fn filebox(
     multiple: bool,
     folder: bool,
     save: bool,
-) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
     let mtm = MainThreadMarker::new().ok_or(Error::NotMainThread)?;
     let delegate = catch(|| {
         let ns_filters = if folder {
@@ -164,7 +164,7 @@ fn filebox(
             .filter_map(|url| {
                 url.absoluteString()
                     .map(|s| from_nsstring(&s))
-                    .map(PathBuf::from)
+                    .map(OsString::from)
             })
             .collect())
     })

--- a/winio-ui-ui-kit/src/file.rs
+++ b/winio-ui-ui-kit/src/file.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::{OsStr, OsString},
     os::fd::{BorrowedFd, FromRawFd, IntoRawFd},
     path::Path,
 };
@@ -64,7 +65,7 @@ enum OpenMode {
     ReadWrite,
 }
 
-fn uri_from_path(path: &Path) -> Result<Retained<NSURL>> {
+fn uri_from_path(path: &OsStr) -> Result<Retained<NSURL>> {
     catch(|| {
         let uri_str = NSString::from_str(&path.to_string_lossy());
         let uri = if let Some(uri) = NSURL::URLWithString(&uri_str)
@@ -75,14 +76,14 @@ fn uri_from_path(path: &Path) -> Result<Retained<NSURL>> {
         {
             uri
         } else {
-            NSURL::from_path(path, false, None).ok_or_else(|| Error::NullPointer)?
+            NSURL::from_path(Path::new(path), false, None).ok_or_else(|| Error::NullPointer)?
         };
         Ok(uri)
     })
     .flatten()
 }
 
-fn open_uri_with_mode(path: &Path, mode: OpenMode) -> Result<UriFile> {
+fn open_uri_with_mode(path: &OsStr, mode: OpenMode) -> Result<UriFile> {
     let uri = uri_from_path(path)?;
     catch(|| {
         if unsafe { !uri.startAccessingSecurityScopedResource() } {
@@ -98,19 +99,36 @@ fn open_uri_with_mode(path: &Path, mode: OpenMode) -> Result<UriFile> {
     .flatten()
 }
 
-pub async fn open_uri(uri: &Path) -> Result<UriFile> {
+pub async fn open_uri(uri: &OsStr) -> Result<UriFile> {
     open_uri_with_mode(uri, OpenMode::Read)
 }
 
-pub async fn create_uri(uri: &Path) -> Result<UriFile> {
+pub async fn create_uri(uri: &OsStr) -> Result<UriFile> {
     open_uri_with_mode(uri, OpenMode::Write)
 }
 
-pub async fn update_uri(uri: &Path) -> Result<UriFile> {
+pub async fn update_uri(uri: &OsStr) -> Result<UriFile> {
     open_uri_with_mode(uri, OpenMode::ReadWrite)
 }
 
-pub use std::fs::{DirEntry as UriDirEntry, FileType as UriFileType};
+pub use std::fs::FileType as UriFileType;
+
+#[derive(Debug)]
+pub struct UriDirEntry(std::fs::DirEntry);
+
+impl UriDirEntry {
+    pub fn path(&self) -> OsString {
+        self.0.path().into_os_string()
+    }
+
+    pub fn file_name(&self) -> OsString {
+        self.0.file_name()
+    }
+
+    pub fn file_type(&self) -> std::io::Result<UriFileType> {
+        self.0.file_type()
+    }
+}
 
 #[derive(Debug)]
 pub struct UriReadDir {
@@ -145,11 +163,13 @@ impl Iterator for UriReadDir {
     type Item = Result<UriDirEntry>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|res| res.map_err(Error::from))
+        self.inner
+            .next()
+            .map(|res| res.map(UriDirEntry).map_err(Error::from))
     }
 }
 
-pub fn read_dir(uri: &Path) -> Result<UriReadDir> {
+pub fn read_dir(uri: &OsStr) -> Result<UriReadDir> {
     let uri = uri_from_path(uri)?;
     UriReadDir::new(uri)
 }

--- a/winio-ui-windows-common/src/filebox.rs
+++ b/winio-ui-windows-common/src/filebox.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::ffi::OsString;
 
 use widestring::U16CString;
 use windows::{
@@ -50,7 +50,7 @@ impl FileBox {
     pub fn open(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         let parent = parent
             .and_then(|p| p.as_window().handle().ok())
             .map(|h| h as isize);
@@ -72,7 +72,7 @@ impl FileBox {
     pub fn open_multiple(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         let parent = parent
             .and_then(|p| p.as_window().handle().ok())
             .map(|h| h as isize);
@@ -94,7 +94,7 @@ impl FileBox {
     pub fn open_folder(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         let parent = parent
             .and_then(|p| p.as_window().handle().ok())
             .map(|h| h as isize);
@@ -116,7 +116,7 @@ impl FileBox {
     pub fn save(
         self,
         parent: Option<impl AsWindow>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         let parent = parent
             .and_then(|p| p.as_window().handle().ok())
             .map(|h| h as isize);
@@ -214,20 +214,20 @@ fn filebox(
 struct FileBoxInner(Option<IFileDialog>, CoInitialize);
 
 impl FileBoxInner {
-    pub fn result(self) -> Result<Option<PathBuf>> {
+    pub fn result(self) -> Result<Option<OsString>> {
         if let Some(dialog) = self.0 {
             unsafe {
                 let item = dialog.GetResult()?;
                 let name_ptr = item.GetDisplayName(SIGDN_FILESYSPATH)?;
                 let name_ptr = CoTaskMemPtr(name_ptr.0);
-                Ok(Some(PathBuf::from(name_ptr.to_string()?)))
+                Ok(Some(OsString::from(name_ptr.to_string()?)))
             }
         } else {
             Ok(None)
         }
     }
 
-    pub fn results(self) -> Result<Vec<PathBuf>> {
+    pub fn results(self) -> Result<Vec<OsString>> {
         if let Some(dialog) = self.0 {
             unsafe {
                 let handle: IFileOpenDialog = dialog.cast()?;
@@ -239,7 +239,7 @@ impl FileBoxInner {
                     let name_ptr = item.GetDisplayName(SIGDN_FILESYSPATH)?;
                     let name_ptr = CoTaskMemPtr(name_ptr.0);
                     let name = name_ptr.to_string()?;
-                    names.push(PathBuf::from(name));
+                    names.push(OsString::from(name));
                 }
                 Ok(names)
             }

--- a/winio/src/ui/file/desktop.rs
+++ b/winio/src/ui/file/desktop.rs
@@ -1,23 +1,56 @@
-use std::path::Path;
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+};
 
 pub use compio::fs::File as UriFile;
 
-pub async fn open_uri(uri: &Path) -> crate::Result<UriFile> {
-    Ok(UriFile::open(uri).await?)
+pub async fn open_uri(uri: &OsStr) -> crate::Result<UriFile> {
+    Ok(UriFile::open(Path::new(uri)).await?)
 }
 
-pub async fn create_uri(uri: &Path) -> crate::Result<UriFile> {
-    Ok(UriFile::create(uri).await?)
+pub async fn create_uri(uri: &OsStr) -> crate::Result<UriFile> {
+    Ok(UriFile::create(Path::new(uri)).await?)
 }
 
-pub async fn update_uri(uri: &Path) -> crate::Result<UriFile> {
+pub async fn update_uri(uri: &OsStr) -> crate::Result<UriFile> {
     Ok(compio::fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open(uri)
+        .open(Path::new(uri))
         .await?)
 }
 
-pub use std::fs::{
-    DirEntry as UriDirEntry, FileType as UriFileType, ReadDir as UriReadDir, read_dir,
-};
+pub use std::fs::FileType as UriFileType;
+
+#[derive(Debug)]
+pub struct UriDirEntry(std::fs::DirEntry);
+
+impl UriDirEntry {
+    pub fn path(&self) -> OsString {
+        self.0.path().into_os_string()
+    }
+
+    pub fn file_name(&self) -> OsString {
+        self.0.file_name()
+    }
+
+    pub fn file_type(&self) -> std::io::Result<UriFileType> {
+        self.0.file_type()
+    }
+}
+
+#[derive(Debug)]
+pub struct UriReadDir(std::fs::ReadDir);
+
+impl Iterator for UriReadDir {
+    type Item = std::io::Result<UriDirEntry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|res| res.map(UriDirEntry))
+    }
+}
+
+pub fn read_dir(uri: &OsStr) -> std::io::Result<UriReadDir> {
+    Ok(UriReadDir(std::fs::read_dir(Path::new(uri))?))
+}

--- a/winio/src/ui/file/mod.rs
+++ b/winio/src/ui/file/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    ffi::OsString,
-    path::{Path, PathBuf},
-};
+use std::ffi::{OsStr, OsString};
 
 use compio::{
     BufResult,
@@ -29,7 +26,7 @@ pub struct UriFile {
 
 impl UriFile {
     /// Opens a file from a URI.
-    pub async fn open(uri: impl AsRef<Path>) -> Result<Self> {
+    pub async fn open(uri: impl AsRef<OsStr>) -> Result<Self> {
         Ok(Self {
             inner: internal::open_uri(uri.as_ref()).await?,
         })
@@ -37,7 +34,7 @@ impl UriFile {
 
     /// Creates a file from a URI. If the file already exists, it will be
     /// truncated.
-    pub async fn create(uri: impl AsRef<Path>) -> Result<Self> {
+    pub async fn create(uri: impl AsRef<OsStr>) -> Result<Self> {
         Ok(Self {
             inner: internal::create_uri(uri.as_ref()).await?,
         })
@@ -45,7 +42,7 @@ impl UriFile {
 
     /// Opens a file from a URI for both reading and writing. The file must
     /// exist.
-    pub async fn update(uri: impl AsRef<Path>) -> Result<Self> {
+    pub async fn update(uri: impl AsRef<OsStr>) -> Result<Self> {
         Ok(Self {
             inner: internal::update_uri(uri.as_ref()).await?,
         })
@@ -88,7 +85,7 @@ pub struct UriDirEntry(internal::UriDirEntry);
 
 impl UriDirEntry {
     /// The URI or the path of the directory entry.
-    pub fn path(&self) -> PathBuf {
+    pub fn path(&self) -> OsString {
         self.0.path()
     }
 
@@ -125,6 +122,6 @@ impl UriFileType {
 }
 
 /// Read a URI directory.
-pub fn read_uri_dir(uri: impl AsRef<Path>) -> Result<UriReadDir> {
+pub fn read_uri_dir(uri: impl AsRef<OsStr>) -> Result<UriReadDir> {
     Ok(UriReadDir(internal::read_dir(uri.as_ref())?))
 }

--- a/winio/src/ui/filebox.rs
+++ b/winio/src/ui/filebox.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::ffi::OsString;
 
 use winio_handle::MaybeBorrowedWindow;
 
@@ -6,7 +6,7 @@ use crate::{sys, sys::Result};
 
 /// A dialog for the user to open or save files.
 ///
-/// The file box uses [`PathBuf`] as returned path type, but it might not be a
+/// The file box uses [`OsString`] as returned path type, but it might not be a
 /// valid Unix path on mobile platforms. Use [`UriFile`](crate::ui::UriFile) and
 /// [`read_uri_dir`](crate::ui::read_uri_dir) to handle the returned path.
 #[derive(Debug, Default, Clone)]
@@ -53,7 +53,7 @@ impl FileBox {
     pub fn open<'a>(
         self,
         parent: impl Into<MaybeBorrowedWindow<'a>>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.0.open(parent.into().0)
     }
 
@@ -68,7 +68,7 @@ impl FileBox {
     pub fn open_multiple<'a>(
         self,
         parent: impl Into<MaybeBorrowedWindow<'a>>,
-    ) -> Result<impl Future<Output = Result<Vec<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Vec<OsString>>> + 'static> {
         self.0.open_multiple(parent.into().0)
     }
 
@@ -83,7 +83,7 @@ impl FileBox {
     pub fn open_folder<'a>(
         self,
         parent: impl Into<MaybeBorrowedWindow<'a>>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.0.open_folder(parent.into().0)
     }
 
@@ -98,7 +98,7 @@ impl FileBox {
     pub fn save<'a>(
         self,
         parent: impl Into<MaybeBorrowedWindow<'a>>,
-    ) -> Result<impl Future<Output = Result<Option<PathBuf>>> + 'static> {
+    ) -> Result<impl Future<Output = Result<Option<OsString>>> + 'static> {
         self.0.save(parent.into().0)
     }
 }


### PR DESCRIPTION
Because it might be a URI instead of a path.

cc @mokurin000 